### PR TITLE
Support different blend modes in `Layer`

### DIFF
--- a/.changeset/big-kiwis-drop.md
+++ b/.changeset/big-kiwis-drop.md
@@ -1,0 +1,22 @@
+---
+"material-composer": patch
+"material-composer-r3f": patch
+---
+
+Renamed `Layer`'s `mix` argument/prop to `opacity`, and added a new `blend`. This prop can take a blend function, or the name of one of the blend functions defined in the new `Blend` export. Its arguments are the original color, the new color, and the value of the `opacity` prop.
+
+The following three are now equivalent (in JSX, but the same applies to the imperative version of `Layer`):
+
+```tsx
+<Layer blend="add">
+  <Modules.Fresnel />
+</Layer>
+
+<Layer opacity={Fresnel()} blend="add">
+  <Modules.Color color="white" />
+</Layer>
+
+<Layer blend={(a, b) => Add(a, Mul(b, Fresnel()))}>
+  <Modules.Color color="white" />
+</Layer>
+```

--- a/apps/examples/src/examples/CombinedModules.tsx
+++ b/apps/examples/src/examples/CombinedModules.tsx
@@ -18,7 +18,7 @@ export const ColorLayer = (props: LayerProps) => {
   const color = useUniformUnit("vec3", new Color(controls.color))
 
   return (
-    <Layer mix={mix} {...props}>
+    <Layer blendAmount={mix} {...props}>
       <Modules.Color color={color} />
     </Layer>
   )
@@ -46,7 +46,7 @@ export const GradientLayer = (props: LayerProps) => {
   const stopC = useUniformUnit("float", controls.stopC)
 
   return (
-    <Layer mix={mix} {...props}>
+    <Layer blendAmount={mix} {...props}>
       <Modules.Gradient
         stops={[
           [colorA, stopA],
@@ -71,7 +71,7 @@ export const FresnelLayer = (props: LayerProps) => {
   const power = useUniformUnit("float", controls.power)
 
   return (
-    <Layer mix={mix} {...props}>
+    <Layer blendAmount={mix} {...props}>
       <Modules.Fresnel intensity={intensity} power={power} />
     </Layer>
   )

--- a/apps/examples/src/examples/CombinedModules.tsx
+++ b/apps/examples/src/examples/CombinedModules.tsx
@@ -18,7 +18,7 @@ export const ColorLayer = (props: LayerProps) => {
   const color = useUniformUnit("vec3", new Color(controls.color))
 
   return (
-    <Layer blendAmount={mix} {...props}>
+    <Layer opacity={mix} {...props}>
       <Modules.Color color={color} />
     </Layer>
   )
@@ -46,7 +46,7 @@ export const GradientLayer = (props: LayerProps) => {
   const stopC = useUniformUnit("float", controls.stopC)
 
   return (
-    <Layer blendAmount={mix} {...props}>
+    <Layer opacity={mix} {...props}>
       <Modules.Gradient
         stops={[
           [colorA, stopA],
@@ -71,7 +71,7 @@ export const FresnelLayer = (props: LayerProps) => {
   const power = useUniformUnit("float", controls.power)
 
   return (
-    <Layer blendAmount={mix} {...props}>
+    <Layer opacity={mix} {...props}>
       <Modules.Fresnel intensity={intensity} power={power} />
     </Layer>
   )

--- a/apps/examples/src/examples/CombinedModules.tsx
+++ b/apps/examples/src/examples/CombinedModules.tsx
@@ -72,7 +72,7 @@ export const FresnelLayer = (props: LayerProps) => {
 
   return (
     <Layer mix={mix} {...props}>
-      <Modules.Fresnel intensity={intensity} power={power} color="white" />
+      <Modules.Fresnel intensity={intensity} power={power} />
     </Layer>
   )
 }

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -19,7 +19,7 @@ export default function HelloWorld() {
             <Modules.Color color="blue" />
           </Layer>
 
-          {/* <Modules.Fresnel color="white" blend="normal" /> */}
+          <Modules.Fresnel />
 
           {/* <Layer mix={Fresnel()}>
             <Modules.Color color="white" />

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -13,13 +13,13 @@ export default function HelloWorld() {
         <sphereGeometry />
 
         <ComposableMaterial>
-          <Modules.Color color="blue" />
+          <Modules.Color color="red" />
 
-          <Layer mix={mix}>
-            <Modules.Color color="green" />
+          <Layer mix={mix} blend="normal">
+            <Modules.Color color="blue" />
           </Layer>
 
-          <Modules.Fresnel color="white" blend="normal" />
+          {/* <Modules.Fresnel color="white" blend="normal" /> */}
 
           {/* <Layer mix={Fresnel()}>
             <Modules.Color color="white" />

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -1,6 +1,7 @@
 import { useControls } from "leva"
 import { ComposableMaterial, Layer, Modules } from "material-composer-r3f"
 import { Description } from "r3f-stage"
+import { Fresnel } from "shader-composer"
 import { useUniformUnit } from "shader-composer-r3f"
 
 export default function HelloWorld() {
@@ -19,11 +20,11 @@ export default function HelloWorld() {
             <Modules.Color color="blue" />
           </Layer>
 
-          <Modules.Fresnel />
+          {/* <Modules.Fresnel /> */}
 
-          {/* <Layer mix={Fresnel()}>
+          <Layer mix={Fresnel()} blend="add">
             <Modules.Color color="white" />
-          </Layer> */}
+          </Layer>
         </ComposableMaterial>
       </mesh>
 

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -1,7 +1,7 @@
 import { useControls } from "leva"
 import { ComposableMaterial, Layer, Modules } from "material-composer-r3f"
 import { Description } from "r3f-stage"
-import { Fresnel } from "shader-composer"
+import { Fresnel, Mix } from "shader-composer"
 import { useUniformUnit } from "shader-composer-r3f"
 
 export default function HelloWorld() {
@@ -16,7 +16,7 @@ export default function HelloWorld() {
         <ComposableMaterial>
           <Modules.Color color="red" />
 
-          <Layer opacity={mix} blend="add">
+          <Layer opacity={mix}>
             <Modules.Color color="blue" />
           </Layer>
 
@@ -24,9 +24,13 @@ export default function HelloWorld() {
             <Modules.Fresnel />
           </Layer>
 
-          <Layer opacity={Fresnel()} blend="add">
+          {/* <Layer opacity={Fresnel()} blend="add">
             <Modules.Color color="white" />
-          </Layer>
+          </Layer> */}
+
+          {/* <Layer blend={(a, b) => Mix(a, b, Fresnel())}>
+            <Modules.Color color="white" />
+          </Layer> */}
         </ComposableMaterial>
       </mesh>
 

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -16,13 +16,15 @@ export default function HelloWorld() {
         <ComposableMaterial>
           <Modules.Color color="red" />
 
-          <Layer mix={mix} blend="normal">
+          <Layer blendAmount={mix} blend="normal">
             <Modules.Color color="blue" />
           </Layer>
 
-          {/* <Modules.Fresnel /> */}
+          <Layer blend="add">
+            <Modules.Fresnel />
+          </Layer>
 
-          <Layer mix={Fresnel()} blend="add">
+          <Layer blendAmount={Fresnel()} blend="add">
             <Modules.Color color="white" />
           </Layer>
         </ComposableMaterial>

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -19,7 +19,7 @@ export default function HelloWorld() {
             <Modules.Color color="green" />
           </Layer>
 
-          <Modules.Fresnel color="white" />
+          <Modules.Fresnel color="white" blend="normal" />
 
           {/* <Layer mix={Fresnel()}>
             <Modules.Color color="white" />

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -16,15 +16,15 @@ export default function HelloWorld() {
         <ComposableMaterial>
           <Modules.Color color="red" />
 
-          <Layer blendAmount={mix} blend="normal">
+          <Layer blendAmount={mix} blendFunction="normal">
             <Modules.Color color="blue" />
           </Layer>
 
-          <Layer blend="add">
+          <Layer blendFunction="add">
             <Modules.Fresnel />
           </Layer>
 
-          <Layer blendAmount={Fresnel()} blend="add">
+          <Layer blendAmount={Fresnel()} blendFunction="add">
             <Modules.Color color="white" />
           </Layer>
         </ComposableMaterial>

--- a/apps/examples/src/examples/HelloWorld.tsx
+++ b/apps/examples/src/examples/HelloWorld.tsx
@@ -16,15 +16,15 @@ export default function HelloWorld() {
         <ComposableMaterial>
           <Modules.Color color="red" />
 
-          <Layer blendAmount={mix} blendFunction="normal">
+          <Layer opacity={mix} blend="add">
             <Modules.Color color="blue" />
           </Layer>
 
-          <Layer blendFunction="add">
+          <Layer blend="add">
             <Modules.Fresnel />
           </Layer>
 
-          <Layer blendAmount={Fresnel()} blendFunction="add">
+          <Layer opacity={Fresnel()} blend="add">
             <Modules.Color color="white" />
           </Layer>
         </ComposableMaterial>

--- a/apps/examples/src/examples/Memoization.tsx
+++ b/apps/examples/src/examples/Memoization.tsx
@@ -47,7 +47,9 @@ const MyMaterial = memo(({ mix }: { mix: Input<"float"> }) => {
     <ComposableMaterial transparent side={DoubleSide}>
       <Modules.Plasma offset={Mul(time, -0.3)} />
 
-      <Layer mix={Smoothstep(Sub(mix, 0.1), Add(mix, 0.1), VertexPosition.x)}>
+      <Layer
+        blendAmount={Smoothstep(Sub(mix, 0.1), Add(mix, 0.1), VertexPosition.x)}
+      >
         <Modules.DistortSurface offset={Mul(time, 0.4)} amplitude={0.3} />
         <Modules.Lava offset={Mul(time, 0.5)} scale={0.3} />
         <Modules.Alpha alpha={1} />

--- a/apps/examples/src/examples/Memoization.tsx
+++ b/apps/examples/src/examples/Memoization.tsx
@@ -48,7 +48,7 @@ const MyMaterial = memo(({ mix }: { mix: Input<"float"> }) => {
       <Modules.Plasma offset={Mul(time, -0.3)} />
 
       <Layer
-        blendAmount={Smoothstep(Sub(mix, 0.1), Add(mix, 0.1), VertexPosition.x)}
+        opacity={Smoothstep(Sub(mix, 0.1), Add(mix, 0.1), VertexPosition.x)}
       >
         <Modules.DistortSurface offset={Mul(time, 0.4)} amplitude={0.3} />
         <Modules.Lava offset={Mul(time, 0.5)} scale={0.3} />

--- a/apps/examples/src/examples/Vanilla.tsx
+++ b/apps/examples/src/examples/Vanilla.tsx
@@ -30,7 +30,7 @@ const vanillaCode = (
     }),
 
     Layer({
-      mix: NormalizePlusMinusOne(Sin(time)),
+      blendAmount: NormalizePlusMinusOne(Sin(time)),
       modules: [
         Modules.DistortSurface({ offset: Mul(time, 0.4), amplitude: 0.3 }),
         Modules.Lava({ offset: Mul(time, 0.2) }),

--- a/apps/examples/src/examples/Vanilla.tsx
+++ b/apps/examples/src/examples/Vanilla.tsx
@@ -30,7 +30,7 @@ const vanillaCode = (
     }),
 
     Layer({
-      blendAmount: NormalizePlusMinusOne(Sin(time)),
+      opacity: NormalizePlusMinusOne(Sin(time)),
       modules: [
         Modules.DistortSurface({ offset: Mul(time, 0.4), amplitude: 0.3 }),
         Modules.Lava({ offset: Mul(time, 0.2) }),

--- a/packages/material-composer-r3f/src/Layer.tsx
+++ b/packages/material-composer-r3f/src/Layer.tsx
@@ -1,4 +1,4 @@
-import { Layer as LayerImpl, LayerOptions } from "material-composer"
+import { Layer as LayerImpl, LayerArgs } from "material-composer"
 import React, { ReactNode, useMemo } from "react"
 import { useDetectShallowChange } from "./lib/use-detect-shallow-change"
 import {
@@ -7,7 +7,7 @@ import {
   useModuleRegistration
 } from "./moduleRegistration"
 
-export type LayerProps = LayerOptions & { children?: ReactNode }
+export type LayerProps = LayerArgs & { children?: ReactNode }
 
 export const Layer = ({ children, ...props }: LayerProps) => {
   const modules = provideModuleRegistration()

--- a/packages/material-composer-r3f/src/reactor.tsx
+++ b/packages/material-composer-r3f/src/reactor.tsx
@@ -1,7 +1,6 @@
 import { Module, ModuleFactory, ModuleFactoryProps } from "material-composer"
 import * as Modules from "material-composer/modules"
 import { FC, useMemo } from "react"
-import { Input } from "shader-composer"
 import { useDetectShallowChange } from "./lib/use-detect-shallow-change"
 import { useModuleRegistration } from "./moduleRegistration"
 

--- a/packages/material-composer-r3f/src/reactor.tsx
+++ b/packages/material-composer-r3f/src/reactor.tsx
@@ -9,9 +9,7 @@ type Modules = typeof Modules
 
 const cache = new Map<string, ModuleComponent<any>>()
 
-type ModuleComponentProps<K extends keyof Modules> = Parameters<
-  Modules[K]
->[0] & { blend?: Input<"float"> }
+type ModuleComponentProps<K extends keyof Modules> = Parameters<Modules[K]>[0]
 
 type ModuleComponent<K extends keyof Modules> = FC<ModuleComponentProps<K>>
 

--- a/packages/material-composer-r3f/src/reactor.tsx
+++ b/packages/material-composer-r3f/src/reactor.tsx
@@ -9,7 +9,9 @@ type Modules = typeof Modules
 
 const cache = new Map<string, ModuleComponent<any>>()
 
-type ModuleComponentProps<K extends keyof Modules> = Parameters<Modules[K]>[0]
+type ModuleComponentProps<
+  K extends keyof Modules
+> = Modules[K] extends ModuleFactory<infer A> ? A : never
 
 type ModuleComponent<K extends keyof Modules> = FC<ModuleComponentProps<K>>
 

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -12,20 +12,20 @@ export type BlendMode = "normal" | "add" | "discard"
 /* TODO: implement additional blend modes */
 
 export const Blend: Record<BlendMode, BlendFunction> = {
-  normal: (a, b, f) => Mix(a, b, f),
+  normal: (a, b, f) => (f === 1 ? b : f === 0 ? a : Mix(a, b, f)),
   discard: (a) => a,
   add: (a, b, f) => Vec3($`min(${a} + ${b}, 1.0) * ${f} + ${a} * (1.0 - ${f})`)
 }
 
 export type LayerArgs = {
   modules?: ModulePipe
-  mix?: Input<"float">
+  blendAmount?: Input<"float">
   blend?: BlendFunction | BlendMode
 }
 
 export const Layer: ModuleFactory<LayerArgs> = ({
   modules = [],
-  mix = 1,
+  blendAmount = 1,
   blend = Blend.normal
 }) => (state) => {
   /* Determine new state */
@@ -36,11 +36,6 @@ export const Layer: ModuleFactory<LayerArgs> = ({
 
   return {
     ...newState,
-    color:
-      mix === 0
-        ? state.color
-        : mix === 1
-        ? newState.color
-        : blendFunction(state.color, newState.color, mix)
+    color: blendFunction(state.color, newState.color, blendAmount)
   }
 }

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -1,11 +1,13 @@
-import { $, Input, Mix, Vec3 } from "shader-composer"
+import { $, Input, Mix, type, Unit } from "shader-composer"
 import { ModuleFactory, ModulePipe, pipeModules } from "."
 
-export type BlendFunction = (
-  a: Input<"vec3">,
-  b: Input<"vec3">,
+export type BlendableType = "float" | "vec2" | "vec3" | "vec4"
+
+export type BlendFunction = <T extends BlendableType>(
+  a: Input<T>,
+  b: Input<T>,
   opacity: Input<"float">
-) => Input<"vec3">
+) => Input<T>
 
 export type BlendMode = "normal" | "add" | "discard"
 
@@ -14,7 +16,8 @@ export type BlendMode = "normal" | "add" | "discard"
 export const Blend: Record<BlendMode, BlendFunction> = {
   normal: (a, b, f) => (f === 1 ? b : f === 0 ? a : Mix(a, b, f)),
   discard: (a) => a,
-  add: (a, b, f) => Vec3($`min(${a} + ${b}, 1.0) * ${f} + ${a} * (1.0 - ${f})`)
+  add: (a, b, f) =>
+    Unit(type(a), $`min(${a} + ${b}, 1.0) * ${f} + ${a} * (1.0 - ${f})`)
 }
 
 export type LayerArgs = {
@@ -35,7 +38,11 @@ export const Layer: ModuleFactory<LayerArgs> = ({
   const blendFunction = typeof blend === "string" ? Blend[blend] : blend
 
   return {
-    ...newState,
-    color: blendFunction(state.color, newState.color, opacity)
+    color: blendFunction(state.color, newState.color, opacity),
+    position: Blend.normal(state.position, newState.position, opacity),
+    alpha: Blend.normal(state.alpha, newState.alpha, opacity),
+    normal: Blend.normal(state.normal, newState.normal, opacity),
+    roughness: Blend.normal(state.roughness, newState.roughness, opacity),
+    metalness: Blend.normal(state.metalness, newState.metalness, opacity)
   }
 }

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -1,4 +1,4 @@
-import { $, Add, Input, Mix, Vec3 } from "shader-composer"
+import { $, Input, Mix, Vec3 } from "shader-composer"
 import { ModuleFactory, ModulePipe, pipeModules } from "."
 
 export type BlendFunction = (

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -9,10 +9,12 @@ export type BlendFunction = (
 
 export type BlendMode = "normal" | "add" | "discard"
 
+/* TODO: implement additional blend modes */
+
 export const Blend: Record<BlendMode, BlendFunction> = {
   normal: (a, b, f) => Mix(a, b, f),
-  add: (a, b, f) => Vec3($`min(${a} + ${b}, 1.0) * ${f} + ${a} * (1.0 - ${f})`),
-  discard: (a) => a
+  discard: (a) => a,
+  add: (a, b, f) => Vec3($`min(${a} + ${b}, 1.0) * ${f} + ${a} * (1.0 - ${f})`)
 }
 
 export type LayerArgs = {

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -20,13 +20,13 @@ export const Blend: Record<BlendMode, BlendFunction> = {
 export type LayerArgs = {
   modules?: ModulePipe
   blendAmount?: Input<"float">
-  blend?: BlendFunction | BlendMode
+  blendFunction?: BlendFunction | BlendMode
 }
 
 export const Layer: ModuleFactory<LayerArgs> = ({
   modules = [],
   blendAmount = 1,
-  blend = Blend.normal
+  blendFunction: blend = Blend.normal
 }) => (state) => {
   /* Determine new state */
   const newState = pipeModules(state, ...modules)

--- a/packages/material-composer/src/Layer.ts
+++ b/packages/material-composer/src/Layer.ts
@@ -19,14 +19,14 @@ export const Blend: Record<BlendMode, BlendFunction> = {
 
 export type LayerArgs = {
   modules?: ModulePipe
-  blendAmount?: Input<"float">
-  blendFunction?: BlendFunction | BlendMode
+  opacity?: Input<"float">
+  blend?: BlendFunction | BlendMode
 }
 
 export const Layer: ModuleFactory<LayerArgs> = ({
   modules = [],
-  blendAmount = 1,
-  blendFunction: blend = Blend.normal
+  opacity = 1,
+  blend = Blend.normal
 }) => (state) => {
   /* Determine new state */
   const newState = pipeModules(state, ...modules)
@@ -36,6 +36,6 @@ export const Layer: ModuleFactory<LayerArgs> = ({
 
   return {
     ...newState,
-    color: blendFunction(state.color, newState.color, blendAmount)
+    color: blendFunction(state.color, newState.color, opacity)
   }
 }

--- a/packages/material-composer/src/modules/Color.ts
+++ b/packages/material-composer/src/modules/Color.ts
@@ -1,4 +1,4 @@
-import { Add, Input, vec3 } from "shader-composer"
+import { Add, Input } from "shader-composer"
 import { Color as ColorImpl, ColorRepresentation } from "three"
 import { ModuleFactory } from ".."
 

--- a/packages/material-composer/src/modules/Color.ts
+++ b/packages/material-composer/src/modules/Color.ts
@@ -1,15 +1,42 @@
-import { Input } from "shader-composer"
+import { Add, Input, vec3 } from "shader-composer"
 import { Color as ColorImpl, ColorRepresentation } from "three"
 import { ModuleFactory } from ".."
 
-export type ColorArgs = {
-  color: Input<"vec3"> | ColorRepresentation
+export type BlendFunction = (
+  a: Input<"vec3">,
+  b: Input<"vec3">
+) => Input<"vec3">
+
+export type BlendMode = "normal" | "add"
+
+export const Blend: Record<BlendMode, BlendFunction> = {
+  normal: (a, b) => b,
+  add: (a, b) => Add(a, b)
 }
 
-export const Color: ModuleFactory<ColorArgs> = ({ color }) => (state) => ({
-  ...state,
-  color:
+export type ColorArgs = {
+  color: Input<"vec3"> | ColorRepresentation
+  blend?: BlendFunction | BlendMode
+}
+
+export const Color: ModuleFactory<ColorArgs> = ({
+  color,
+  blend = Blend.normal
+}) => (state) => {
+  /* Determine new color */
+  const newColor =
     typeof color === "string" || typeof color === "number"
       ? new ColorImpl(color)
       : color
-})
+
+  /* Determine blend function */
+  const blendFunction = typeof blend === "string" ? Blend[blend] : blend
+
+  /* Apply blending */
+  const blendedColor = blendFunction(state.color, newColor)
+
+  return {
+    ...state,
+    color: blendedColor
+  }
+}

--- a/packages/material-composer/src/modules/Color.ts
+++ b/packages/material-composer/src/modules/Color.ts
@@ -7,11 +7,12 @@ export type BlendFunction = (
   b: Input<"vec3">
 ) => Input<"vec3">
 
-export type BlendMode = "normal" | "add"
+export type BlendMode = "normal" | "add" | "discard"
 
 export const Blend: Record<BlendMode, BlendFunction> = {
   normal: (a, b) => b,
-  add: (a, b) => Add(a, b)
+  add: (a, b) => Add(a, b),
+  discard: (a, b) => a
 }
 
 export type ColorArgs = {

--- a/packages/material-composer/src/modules/Color.ts
+++ b/packages/material-composer/src/modules/Color.ts
@@ -1,43 +1,20 @@
-import { Add, Input } from "shader-composer"
+import { Input } from "shader-composer"
 import { Color as ColorImpl, ColorRepresentation } from "three"
 import { ModuleFactory } from ".."
 
-export type BlendFunction = (
-  a: Input<"vec3">,
-  b: Input<"vec3">
-) => Input<"vec3">
-
-export type BlendMode = "normal" | "add" | "discard"
-
-export const Blend: Record<BlendMode, BlendFunction> = {
-  normal: (a, b) => b,
-  add: (a, b) => Add(a, b),
-  discard: (a, b) => a
-}
-
 export type ColorArgs = {
   color: Input<"vec3"> | ColorRepresentation
-  blend?: BlendFunction | BlendMode
 }
 
-export const Color: ModuleFactory<ColorArgs> = ({
-  color,
-  blend = Blend.normal
-}) => (state) => {
+export const Color: ModuleFactory<ColorArgs> = ({ color }) => (state) => {
   /* Determine new color */
   const newColor =
     typeof color === "string" || typeof color === "number"
       ? new ColorImpl(color)
       : color
 
-  /* Determine blend function */
-  const blendFunction = typeof blend === "string" ? Blend[blend] : blend
-
-  /* Apply blending */
-  const blendedColor = blendFunction(state.color, newColor)
-
   return {
     ...state,
-    color: blendedColor
+    color: newColor
   }
 }

--- a/packages/material-composer/src/modules/Fresnel.ts
+++ b/packages/material-composer/src/modules/Fresnel.ts
@@ -6,10 +6,11 @@ import { Color, ColorArgs } from "./Color"
 export type FresnelArgs = FresnelProps & ColorArgs
 
 export const Fresnel: ModuleFactory<FresnelArgs> = ({
-  color = "white",
+  color,
+  blend,
   ...props
 }) =>
   Layer({
     mix: FresnelUnit(props),
-    modules: [Color({ color })]
+    modules: [Color({ color, blend })]
   })

--- a/packages/material-composer/src/modules/Fresnel.ts
+++ b/packages/material-composer/src/modules/Fresnel.ts
@@ -3,14 +3,10 @@ import { ModuleFactory } from ".."
 import { Layer } from "../Layer"
 import { Color, ColorArgs } from "./Color"
 
-export type FresnelArgs = FresnelProps & ColorArgs
+export type FresnelArgs = FresnelProps
 
-export const Fresnel: ModuleFactory<FresnelArgs> = ({
-  color,
-  blend,
-  ...props
-}) =>
+export const Fresnel: ModuleFactory<FresnelArgs> = (props) =>
   Layer({
     mix: FresnelUnit(props),
-    modules: [Color({ color, blend })]
+    modules: [Color({ color: "white" })]
   })

--- a/packages/material-composer/src/modules/Fresnel.ts
+++ b/packages/material-composer/src/modules/Fresnel.ts
@@ -7,6 +7,6 @@ export type FresnelArgs = FresnelProps
 
 export const Fresnel: ModuleFactory<FresnelArgs> = (props) =>
   Layer({
-    blendAmount: FresnelUnit(props),
+    opacity: FresnelUnit(props),
     modules: [Color({ color: "white" })]
   })

--- a/packages/material-composer/src/modules/Fresnel.ts
+++ b/packages/material-composer/src/modules/Fresnel.ts
@@ -7,6 +7,6 @@ export type FresnelArgs = FresnelProps
 
 export const Fresnel: ModuleFactory<FresnelArgs> = (props) =>
   Layer({
-    mix: FresnelUnit(props),
+    blendAmount: FresnelUnit(props),
     modules: [Color({ color: "white" })]
   })

--- a/packages/material-composer/src/modules/Fresnel.ts
+++ b/packages/material-composer/src/modules/Fresnel.ts
@@ -1,7 +1,7 @@
 import { Fresnel as FresnelUnit, FresnelProps } from "shader-composer"
 import { ModuleFactory } from ".."
 import { Layer } from "../Layer"
-import { Color, ColorArgs } from "./Color"
+import { Color } from "./Color"
 
 export type FresnelArgs = FresnelProps
 


### PR DESCRIPTION
This adds a new `blend` prop to the `Layer` module/component. This prop can take a blend function, or the name of one of the blend functions defined in the new `Blend` export. Its arguments are the original color, the new color, and the value of the `opacity` prop.

The following three are now equivalent:

```tsx
<Layer blend="add">
  <Modules.Fresnel />
</Layer>

<Layer opacity={Fresnel()} blend="add">
  <Modules.Color color="white" />
</Layer>

<Layer blend={(a, b) => Add(a, Mul(b, Fresnel()))}>
  <Modules.Color color="white" />
</Layer>
```

### etc.

- Fixes #20